### PR TITLE
Make setup instructions more clear

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,13 +13,9 @@ Install
 Setup
 -----
 
-Create a new application under your organization in GitHub. Enter the **Authorization
-callback URL** as the prefix to your Sentry installation:
-
-::
-
-    https://example.sentry.com
-
+Create a new application under your organization in GitHub. In the **Authorization
+callback URL** field, enter the prefix to your Sentry installation, for example: 
+``https://sentry.yourdomain.com``.
 
 Once done, grab your API keys and drop them in your ``sentry.conf.py``:
 
@@ -28,7 +24,7 @@ Once done, grab your API keys and drop them in your ``sentry.conf.py``:
     GITHUB_APP_ID = ""
 
     GITHUB_API_SECRET = ""
-
+    
 
 Verified email addresses can optionally be required:
 

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,13 @@ Verified email addresses can optionally be required:
     GITHUB_REQUIRE_VERIFIED_EMAIL = True
 
 
+If you want to limit access to users of a single GitHub organization, add:
+
+.. code-block:: python
+
+    GITHUB_ORGANIZATION = 'myorg'
+
+
 Optionally you may also specify the domain (for GHE users):
 
 .. code-block:: python


### PR DESCRIPTION
I was thrown off by instructions from an earlier version that talked about `/account/settings/social/associate/complete/github/`, and the current wording didn't make clear to me that this has changed. Hopefully this does to others :)